### PR TITLE
INLINABLE pragma for application

### DIFF
--- a/src/Tie/Codegen/Operation.hs
+++ b/src/Tie/Codegen/Operation.hs
@@ -94,7 +94,10 @@ codegenOperations resolver operations = do
                     )
               )
 
-  pure (dataApiDecl <> PP.line <> PP.line <> apiDecl)
+      inlineablePragma = 
+        "{-#" <+> "INLINABLE" <+> "application" <+> "#-}"
+
+  pure (dataApiDecl <> PP.line <> PP.line <> apiDecl <> PP.line <> inlineablePragma)
 
 codegenApiType :: Monad m => Resolver m -> [Operation] -> m (PP.Doc ann)
 codegenApiType resolver operations = do

--- a/test/golden/bug-1.yaml.out
+++ b/test/golden/bug-1.yaml.out
@@ -63,6 +63,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 

--- a/test/golden/csv.yaml.out
+++ b/test/golden/csv.yaml.out
@@ -77,6 +77,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 

--- a/test/golden/datetime.yaml.out
+++ b/test/golden/datetime.yaml.out
@@ -63,6 +63,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 

--- a/test/golden/enum-bug.yaml.out
+++ b/test/golden/enum-bug.yaml.out
@@ -66,6 +66,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 

--- a/test/golden/enum.yaml.out
+++ b/test/golden/enum.yaml.out
@@ -130,6 +130,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 

--- a/test/golden/haskell-ext.yaml.out
+++ b/test/golden/haskell-ext.yaml.out
@@ -67,6 +67,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 

--- a/test/golden/headers.yaml.out
+++ b/test/golden/headers.yaml.out
@@ -94,6 +94,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 

--- a/test/golden/lists.yaml.out
+++ b/test/golden/lists.yaml.out
@@ -93,6 +93,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 

--- a/test/golden/numbers.yaml.out
+++ b/test/golden/numbers.yaml.out
@@ -63,6 +63,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 

--- a/test/golden/object-without-type.yaml.out
+++ b/test/golden/object-without-type.yaml.out
@@ -63,6 +63,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 

--- a/test/golden/oneof.yaml.out
+++ b/test/golden/oneof.yaml.out
@@ -93,6 +93,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 

--- a/test/golden/petstore.yaml.out
+++ b/test/golden/petstore.yaml.out
@@ -94,6 +94,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 

--- a/test/golden/test1.yaml.out
+++ b/test/golden/test1.yaml.out
@@ -97,6 +97,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 


### PR DESCRIPTION
INLINABLE makes sure to include the applications unfolding into
the haskell interface (despite it's possibly large size). It allows
users to specialize the function at use-site:

```
import Scarf.Public.Api (application)

{-# SPECIALIZE application @AppIO #-}

```
