### PR TITLE
Don't emit Exception instance for responses

### DIFF
--- a/src/Tie/Codegen/Cabal.hs
+++ b/src/Tie/Codegen/Cabal.hs
@@ -14,7 +14,6 @@ codegenCabalFile packageName exposedModules extraPackages =
             "attoparsec",
             "base",
             "bytestring",
-            "exceptions",
             "ghc-prim",
             "http-api-data",
             "http-types",

--- a/src/Tie/Codegen/Imports.hs
+++ b/src/Tie/Codegen/Imports.hs
@@ -47,8 +47,6 @@ codegenModuleHeader moduleName =
     <> PP.line
     <> "import" <+> "qualified" <+> "Control.Monad"
     <> PP.line
-    <> "import" <+> "qualified" <+> "Control.Monad.Catch"
-    <> PP.line
     <> "import" <+> "qualified" <+> "Control.Monad.IO.Class"
     <> PP.line
     <> "import" <+> "qualified" <+> "Data.Aeson"

--- a/src/Tie/Codegen/Operation.hs
+++ b/src/Tie/Codegen/Operation.hs
@@ -45,7 +45,7 @@ codegenOperations resolver operations = do
   operationsCode <- traverse (codegenOperation resolver) (Map.elems groupedOperations)
   let apiDecl =
         -- TODO instead of "application" take name from openapi spec
-        "application" <+> "::" <+> "(" <> "Control.Monad.Catch.MonadCatch" <+> "m" <> "," <+> "Control.Monad.IO.Class.MonadIO" <+> "m" <> ")" <+> "=>" <+> "(" <> "forall" <+> "a" <+> "." <+> "Network.Wai.Request" <+> "->" <+> "m"
+        "application" <+> "::" <+> "(" <> "Control.Monad.IO.Class.MonadIO" <+> "m" <> ")" <+> "=>" <+> "(" <> "forall" <+> "a" <+> "." <+> "Network.Wai.Request" <+> "->" <+> "m"
           <+> "a"
           <+> "->"
           <+> "IO"
@@ -94,7 +94,10 @@ codegenOperations resolver operations = do
                     )
               )
 
-  pure (dataApiDecl <> PP.line <> PP.line <> apiDecl)
+      inlineablePragma = 
+        "{-#" <+> "INLINABLE" <+> "application" <+> "#-}"
+
+  pure (dataApiDecl <> PP.line <> PP.line <> apiDecl <> PP.line <> inlineablePragma)
 
 codegenApiType :: Monad m => Resolver m -> [Operation] -> m (PP.Doc ann)
 codegenApiType resolver operations = do
@@ -187,18 +190,16 @@ codegenCallApiMember operationName path queryParams headerParams requestBody =
   "run" <+> "request" <+> "(" <> "do" <> PP.line
     <> PP.indent
       4
-      ( "response" <+> "<-" <+> "Control.Monad.Catch.handle" <+> "pure"
-          <+> "("
-            <> PP.hsep
-              ( concat
-                  [ [toApiMemberName operationName, "api"],
-                    [toParamBinder name | VariableSegment Param {name} <- path],
-                    [toParamBinder name | Param {name} <- queryParams],
-                    [toParamBinder name | Param {name} <- headerParams],
-                    ["body" | Just {} <- [requestBody]]
-                  ]
-              )
-            <> ")"
+      ( "response" <+> "<-"
+          <+> PP.hsep
+            ( concat
+                [ [toApiMemberName operationName, "api"],
+                  [toParamBinder name | VariableSegment Param {name} <- path],
+                  [toParamBinder name | Param {name} <- queryParams],
+                  [toParamBinder name | Param {name} <- headerParams],
+                  ["body" | Just {} <- [requestBody]]
+                ]
+            )
             <> PP.line
             <> "Control.Monad.IO.Class.liftIO"
           <+> "(" <> "respond"

--- a/src/Tie/Codegen/Response.hs
+++ b/src/Tie/Codegen/Response.hs
@@ -112,14 +112,10 @@ codegenResponses resolver Operation {..} = do
             ( "show" <+> "_" <+> "=" <+> "\"" <> toApiResponseTypeName name <+> "{}" <> "\""
             )
 
-      exceptionInstance =
-        "instance" <+> "Control.Exception.Exception" <+> toApiResponseTypeName name
-
   pure
     ( PP.vsep $
         intersperse mempty $
-          [decl, exceptionInstance, instances]
-            ++ [showInstance | requiresCustomShowInstance]
+          [decl, instances] ++ [showInstance | requiresCustomShowInstance]
     )
 
 codegenToResponses :: Name -> [(Int, Response)] -> Maybe Response -> Doc ann

--- a/test/golden/bug-1.yaml.out
+++ b/test/golden/bug-1.yaml.out
@@ -11,7 +11,6 @@ module Test.Api where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -45,14 +44,14 @@ data Api m = Api {
         m TestResponse
 }
 
-application :: (Control.Monad.Catch.MonadCatch m, Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
+application :: (Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
 application run api notFound request respond =
     case Network.Wai.pathInfo request of
         ["test"] ->
             case Network.Wai.requestMethod request of
                 "GET" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (test api)
+                        response <- test api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -63,6 +62,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 
@@ -285,7 +285,6 @@ module Test.Response.Test where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -314,8 +313,6 @@ data TestResponse
     = TestResponse200 [ TestResponseBody200 ]
     deriving (Show)
 
-instance Control.Exception.Exception TestResponse
-
 instance ToResponse TestResponse where
     toResponse (TestResponse200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -331,7 +328,6 @@ library
     , attoparsec
     , base
     , bytestring
-    , exceptions
     , ghc-prim
     , http-api-data
     , http-types

--- a/test/golden/csv.yaml.out
+++ b/test/golden/csv.yaml.out
@@ -11,7 +11,6 @@ module Test.Api where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -49,14 +48,14 @@ data Api m = Api {
         m Test2Response
 }
 
-application :: (Control.Monad.Catch.MonadCatch m, Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
+application :: (Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
 application run api notFound request respond =
     case Network.Wai.pathInfo request of
         ["test"] ->
             case Network.Wai.requestMethod request of
                 "GET" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (test api)
+                        response <- test api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -66,7 +65,7 @@ application run api notFound request respond =
             case Network.Wai.requestMethod request of
                 "GET" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (test2 api)
+                        response <- test2 api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -77,6 +76,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 
@@ -299,7 +299,6 @@ module Test.Response.Test where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -325,8 +324,6 @@ import Test.Response
 data TestResponse
     = TestResponse200 Network.Wai.StreamingBody
 
-instance Control.Exception.Exception TestResponse
-
 instance ToResponse TestResponse where
     toResponse (TestResponse200 x) =
         Network.Wai.responseStream (toEnum 200) ([(Network.HTTP.Types.hContentType, "text/csv")]) x
@@ -347,7 +344,6 @@ module Test.Response.Test2 where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -374,8 +370,6 @@ data Test2Response
     = Test2Response200 Data.Aeson.Value
     deriving (Show)
 
-instance Control.Exception.Exception Test2Response
-
 instance ToResponse Test2Response where
     toResponse (Test2Response200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -391,7 +385,6 @@ library
     , attoparsec
     , base
     , bytestring
-    , exceptions
     , ghc-prim
     , http-api-data
     , http-types

--- a/test/golden/datetime.yaml.out
+++ b/test/golden/datetime.yaml.out
@@ -11,7 +11,6 @@ module Test.Api where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -45,14 +44,14 @@ data Api m = Api {
         m TestResponse
 }
 
-application :: (Control.Monad.Catch.MonadCatch m, Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
+application :: (Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
 application run api notFound request respond =
     case Network.Wai.pathInfo request of
         ["test"] ->
             case Network.Wai.requestMethod request of
                 "GET" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (test api)
+                        response <- test api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -63,6 +62,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 
@@ -285,7 +285,6 @@ module Test.Response.Test where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -312,8 +311,6 @@ data TestResponse
     = TestResponse200 Test
     deriving (Show)
 
-instance Control.Exception.Exception TestResponse
-
 instance ToResponse TestResponse where
     toResponse (TestResponse200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -331,7 +328,6 @@ module Test.Schemas.Test where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -390,7 +386,6 @@ library
     , attoparsec
     , base
     , bytestring
-    , exceptions
     , ghc-prim
     , http-api-data
     , http-types

--- a/test/golden/enum-bug.yaml.out
+++ b/test/golden/enum-bug.yaml.out
@@ -11,7 +11,6 @@ module Test.Api where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -47,7 +46,7 @@ data Api m = Api {
         m DummyResponse
 }
 
-application :: (Control.Monad.Catch.MonadCatch m, Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
+application :: (Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
 application run api notFound request respond =
     case Network.Wai.pathInfo request of
         ["v2", __entity, "packages"] ->
@@ -55,7 +54,7 @@ application run api notFound request respond =
                 case Network.Wai.requestMethod request of
                     "GET" ->
                         run request (do
-                            response <- Control.Monad.Catch.handle pure (dummy api __entity)
+                            response <- dummy api __entity
                             Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                         )
                     x ->
@@ -66,6 +65,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 
@@ -288,7 +288,6 @@ module Test.Response.Dummy where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -315,8 +314,6 @@ data DummyResponse
     = DummyResponse200 Package
     deriving (Show)
 
-instance Control.Exception.Exception DummyResponse
-
 instance ToResponse DummyResponse where
     toResponse (DummyResponse200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -334,7 +331,6 @@ module Test.Schemas.DockerPackage where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -420,7 +416,6 @@ module Test.Schemas.FilePackage where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -506,7 +501,6 @@ module Test.Schemas.Package where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -560,7 +554,6 @@ module Test.Schemas.PackageBase where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -637,7 +630,6 @@ module Test.Schemas.PackageType where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -716,7 +708,6 @@ library
     , attoparsec
     , base
     , bytestring
-    , exceptions
     , ghc-prim
     , http-api-data
     , http-types

--- a/test/golden/enum.yaml.out
+++ b/test/golden/enum.yaml.out
@@ -11,7 +11,6 @@ module Test.Api where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -69,14 +68,14 @@ data Api m = Api {
         m ListPackages5Response
 }
 
-application :: (Control.Monad.Catch.MonadCatch m, Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
+application :: (Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
 application run api notFound request respond =
     case Network.Wai.pathInfo request of
         ["packages"] ->
             case Network.Wai.requestMethod request of
                 "GET" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (listPackages api)
+                        response <- listPackages api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -86,7 +85,7 @@ application run api notFound request respond =
             case Network.Wai.requestMethod request of
                 "GET" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (listPackages2 api)
+                        response <- listPackages2 api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -97,7 +96,7 @@ application run api notFound request respond =
                 "GET" ->
                     optionalQueryParameter "order" False (\__order request respond ->
                         run request (do
-                            response <- Control.Monad.Catch.handle pure (listPackages3 api __order)
+                            response <- listPackages3 api __order
                             Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                         )) request respond
                 x ->
@@ -108,7 +107,7 @@ application run api notFound request respond =
                 "GET" ->
                     optionalQueryParameter "order" False (\__order request respond ->
                         run request (do
-                            response <- Control.Monad.Catch.handle pure (listPackages4 api __order)
+                            response <- listPackages4 api __order
                             Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                         )) request respond
                 x ->
@@ -119,7 +118,7 @@ application run api notFound request respond =
                 case Network.Wai.requestMethod request of
                     "GET" ->
                         run request (do
-                            response <- Control.Monad.Catch.handle pure (listPackages5 api __time_range)
+                            response <- listPackages5 api __time_range
                             Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                         )
                     x ->
@@ -130,6 +129,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 
@@ -352,7 +352,6 @@ module Test.Response.ListPackages where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -379,8 +378,6 @@ data ListPackagesResponse
     = ListPackagesResponse200 Package
     deriving (Show)
 
-instance Control.Exception.Exception ListPackagesResponse
-
 instance ToResponse ListPackagesResponse where
     toResponse (ListPackagesResponse200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -398,7 +395,6 @@ module Test.Response.ListPackages2 where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -464,8 +460,6 @@ data ListPackages2Response
     = ListPackages2Response200 ListPackages2ResponseBody200
     deriving (Show)
 
-instance Control.Exception.Exception ListPackages2Response
-
 instance ToResponse ListPackages2Response where
     toResponse (ListPackages2Response200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -483,7 +477,6 @@ module Test.Response.ListPackages3 where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -543,8 +536,6 @@ data ListPackages3Response
     = ListPackages3Response201
     deriving (Show)
 
-instance Control.Exception.Exception ListPackages3Response
-
 instance ToResponse ListPackages3Response where
     toResponse (ListPackages3Response201) =
         Network.Wai.responseBuilder (toEnum 201) ([]) mempty
@@ -562,7 +553,6 @@ module Test.Response.ListPackages4 where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -589,8 +579,6 @@ data ListPackages4Response
     = ListPackages4Response201
     deriving (Show)
 
-instance Control.Exception.Exception ListPackages4Response
-
 instance ToResponse ListPackages4Response where
     toResponse (ListPackages4Response201) =
         Network.Wai.responseBuilder (toEnum 201) ([]) mempty
@@ -608,7 +596,6 @@ module Test.Response.ListPackages5 where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -635,8 +622,6 @@ data ListPackages5Response
     = ListPackages5Response201
     deriving (Show)
 
-instance Control.Exception.Exception ListPackages5Response
-
 instance ToResponse ListPackages5Response where
     toResponse (ListPackages5Response201) =
         Network.Wai.responseBuilder (toEnum 201) ([]) mempty
@@ -654,7 +639,6 @@ module Test.Schemas.InsightsTimeRange where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -729,7 +713,6 @@ module Test.Schemas.Order where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -798,7 +781,6 @@ module Test.Schemas.Package where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -871,7 +853,6 @@ library
     , attoparsec
     , base
     , bytestring
-    , exceptions
     , ghc-prim
     , http-api-data
     , http-types

--- a/test/golden/haskell-ext.yaml.out
+++ b/test/golden/haskell-ext.yaml.out
@@ -11,7 +11,6 @@ module Test.Api where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -48,7 +47,7 @@ data Api m = Api {
         m TestResponse
 }
 
-application :: (Control.Monad.Catch.MonadCatch m, Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
+application :: (Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
 application run api notFound request respond =
     case Network.Wai.pathInfo request of
         ["test", __xx] ->
@@ -56,7 +55,7 @@ application run api notFound request respond =
                 case Network.Wai.requestMethod request of
                     "GET" ->
                         run request (do
-                            response <- Control.Monad.Catch.handle pure (test api __xx)
+                            response <- test api __xx
                             Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                         )
                     x ->
@@ -67,6 +66,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 
@@ -289,7 +289,6 @@ module Test.Response.Test where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -316,8 +315,6 @@ data TestResponse
     = TestResponse200 Test
     deriving (Show)
 
-instance Control.Exception.Exception TestResponse
-
 instance ToResponse TestResponse where
     toResponse (TestResponse200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -335,7 +332,6 @@ module Test.Schemas.Test where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -390,7 +386,6 @@ library
     , attoparsec
     , base
     , bytestring
-    , exceptions
     , ghc-prim
     , http-api-data
     , http-types

--- a/test/golden/headers.yaml.out
+++ b/test/golden/headers.yaml.out
@@ -11,7 +11,6 @@ module Test.Api where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -55,7 +54,7 @@ data Api m = Api {
         m Test2Response
 }
 
-application :: (Control.Monad.Catch.MonadCatch m, Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
+application :: (Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
 application run api notFound request respond =
     case Network.Wai.pathInfo request of
         ["test"] ->
@@ -63,7 +62,7 @@ application run api notFound request respond =
                 "GET" ->
                     optionalHeader "x-next" (\__x_next request respond ->
                         run request (do
-                            response <- Control.Monad.Catch.handle pure (test api __x_next)
+                            response <- test api __x_next
                             Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                         )) request respond
                 x ->
@@ -73,7 +72,7 @@ application run api notFound request respond =
             case Network.Wai.requestMethod request of
                 "GET" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (test1 api)
+                        response <- test1 api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -83,7 +82,7 @@ application run api notFound request respond =
             case Network.Wai.requestMethod request of
                 "GET" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (test2 api)
+                        response <- test2 api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -94,6 +93,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 
@@ -316,7 +316,6 @@ module Test.Response.Test where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -343,8 +342,6 @@ data TestResponse
     = TestResponse200 Test
     deriving (Show)
 
-instance Control.Exception.Exception TestResponse
-
 instance ToResponse TestResponse where
     toResponse (TestResponse200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -362,7 +359,6 @@ module Test.Response.Test1 where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -389,8 +385,6 @@ data Test1Response
     = Test1Response201 (Data.Maybe.Maybe (Data.Text.Text))
     deriving (Show)
 
-instance Control.Exception.Exception Test1Response
-
 instance ToResponse Test1Response where
     toResponse (Test1Response201 __Location) =
         Network.Wai.responseBuilder (toEnum 201) ([("Location", Web.HttpApiData.toHeader __Location) | Just __Location <- [__Location]] ++ []) mempty
@@ -408,7 +402,6 @@ module Test.Response.Test2 where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -435,8 +428,6 @@ data Test2Response
     = Test2Response201 Data.Text.Text
     deriving (Show)
 
-instance Control.Exception.Exception Test2Response
-
 instance ToResponse Test2Response where
     toResponse (Test2Response201 __Location) =
         Network.Wai.responseBuilder (toEnum 201) ([("Location", Web.HttpApiData.toHeader __Location)]) mempty
@@ -454,7 +445,6 @@ module Test.Schemas.Test where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -513,7 +503,6 @@ library
     , attoparsec
     , base
     , bytestring
-    , exceptions
     , ghc-prim
     , http-api-data
     , http-types

--- a/test/golden/lists.yaml.out
+++ b/test/golden/lists.yaml.out
@@ -11,7 +11,6 @@ module Test.Api where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -55,14 +54,14 @@ data Api m = Api {
         m ListPackages3Response
 }
 
-application :: (Control.Monad.Catch.MonadCatch m, Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
+application :: (Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
 application run api notFound request respond =
     case Network.Wai.pathInfo request of
         ["packages"] ->
             case Network.Wai.requestMethod request of
                 "GET" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (listPackages api)
+                        response <- listPackages api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -72,7 +71,7 @@ application run api notFound request respond =
             case Network.Wai.requestMethod request of
                 "GET" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (listPackages2 api)
+                        response <- listPackages2 api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -82,7 +81,7 @@ application run api notFound request respond =
             case Network.Wai.requestMethod request of
                 "GET" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (listPackages3 api)
+                        response <- listPackages3 api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -93,6 +92,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 
@@ -315,7 +315,6 @@ module Test.Response.ListPackages where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -342,8 +341,6 @@ data ListPackagesResponse
     = ListPackagesResponse200 Packages
     deriving (Show)
 
-instance Control.Exception.Exception ListPackagesResponse
-
 instance ToResponse ListPackagesResponse where
     toResponse (ListPackagesResponse200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -361,7 +358,6 @@ module Test.Response.ListPackages2 where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -388,8 +384,6 @@ data ListPackages2Response
     = ListPackages2Response200 [ Package ]
     deriving (Show)
 
-instance Control.Exception.Exception ListPackages2Response
-
 instance ToResponse ListPackages2Response where
     toResponse (ListPackages2Response200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -407,7 +401,6 @@ module Test.Response.ListPackages3 where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -434,8 +427,6 @@ data ListPackages3Response
     = ListPackages3Response200 [ Inline ]
     deriving (Show)
 
-instance Control.Exception.Exception ListPackages3Response
-
 instance ToResponse ListPackages3Response where
     toResponse (ListPackages3Response200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -453,7 +444,6 @@ module Test.Schemas.Inline where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -512,7 +502,6 @@ module Test.Schemas.Package where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -569,7 +558,6 @@ module Test.Schemas.Packages where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -605,7 +593,6 @@ library
     , attoparsec
     , base
     , bytestring
-    , exceptions
     , ghc-prim
     , http-api-data
     , http-types

--- a/test/golden/numbers.yaml.out
+++ b/test/golden/numbers.yaml.out
@@ -11,7 +11,6 @@ module Test.Api where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -45,14 +44,14 @@ data Api m = Api {
         m TestResponse
 }
 
-application :: (Control.Monad.Catch.MonadCatch m, Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
+application :: (Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
 application run api notFound request respond =
     case Network.Wai.pathInfo request of
         ["test"] ->
             case Network.Wai.requestMethod request of
                 "GET" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (test api)
+                        response <- test api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -63,6 +62,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 
@@ -285,7 +285,6 @@ module Test.Response.Test where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -312,8 +311,6 @@ data TestResponse
     = TestResponse200 Test
     deriving (Show)
 
-instance Control.Exception.Exception TestResponse
-
 instance ToResponse TestResponse where
     toResponse (TestResponse200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -331,7 +328,6 @@ module Test.Schemas.Test where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -406,7 +402,6 @@ library
     , attoparsec
     , base
     , bytestring
-    , exceptions
     , ghc-prim
     , http-api-data
     , http-types

--- a/test/golden/object-without-type.yaml.out
+++ b/test/golden/object-without-type.yaml.out
@@ -11,7 +11,6 @@ module Test.Api where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -45,14 +44,14 @@ data Api m = Api {
         m TestResponse
 }
 
-application :: (Control.Monad.Catch.MonadCatch m, Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
+application :: (Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
 application run api notFound request respond =
     case Network.Wai.pathInfo request of
         ["test"] ->
             case Network.Wai.requestMethod request of
                 "GET" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (test api)
+                        response <- test api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -63,6 +62,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 
@@ -285,7 +285,6 @@ module Test.Response.Test where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -314,8 +313,6 @@ data TestResponse
     = TestResponse200 TestResponseBody200
     deriving (Show)
 
-instance Control.Exception.Exception TestResponse
-
 instance ToResponse TestResponse where
     toResponse (TestResponse200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -331,7 +328,6 @@ library
     , attoparsec
     , base
     , bytestring
-    , exceptions
     , ghc-prim
     , http-api-data
     , http-types

--- a/test/golden/oneof.yaml.out
+++ b/test/golden/oneof.yaml.out
@@ -11,7 +11,6 @@ module Test.Api where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -55,14 +54,14 @@ data Api m = Api {
         m ListPackages3Response
 }
 
-application :: (Control.Monad.Catch.MonadCatch m, Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
+application :: (Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
 application run api notFound request respond =
     case Network.Wai.pathInfo request of
         ["packages"] ->
             case Network.Wai.requestMethod request of
                 "GET" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (listPackages api)
+                        response <- listPackages api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -72,7 +71,7 @@ application run api notFound request respond =
             case Network.Wai.requestMethod request of
                 "GET" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (listPackages2 api)
+                        response <- listPackages2 api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -82,7 +81,7 @@ application run api notFound request respond =
             case Network.Wai.requestMethod request of
                 "GET" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (listPackages3 api)
+                        response <- listPackages3 api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -93,6 +92,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 
@@ -315,7 +315,6 @@ module Test.Response.ListPackages where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -342,8 +341,6 @@ data ListPackagesResponse
     = ListPackagesResponse200 PetOrPackage
     deriving (Show)
 
-instance Control.Exception.Exception ListPackagesResponse
-
 instance ToResponse ListPackagesResponse where
     toResponse (ListPackagesResponse200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -361,7 +358,6 @@ module Test.Response.ListPackages2 where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -388,8 +384,6 @@ data ListPackages2Response
     = ListPackages2Response200 Inline
     deriving (Show)
 
-instance Control.Exception.Exception ListPackages2Response
-
 instance ToResponse ListPackages2Response where
     toResponse (ListPackages2Response200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -407,7 +401,6 @@ module Test.Response.ListPackages3 where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -434,8 +427,6 @@ data ListPackages3Response
     = ListPackages3Response200 Inline2
     deriving (Show)
 
-instance Control.Exception.Exception ListPackages3Response
-
 instance ToResponse ListPackages3Response where
     toResponse (ListPackages3Response200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -453,7 +444,6 @@ module Test.Schemas.Inline where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -531,7 +521,6 @@ module Test.Schemas.Inline2 where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -626,7 +615,6 @@ module Test.Schemas.Package where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -683,7 +671,6 @@ module Test.Schemas.Pet where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -740,7 +727,6 @@ module Test.Schemas.PetOrPackage where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -798,7 +784,6 @@ library
     , attoparsec
     , base
     , bytestring
-    , exceptions
     , ghc-prim
     , http-api-data
     , http-types

--- a/test/golden/petstore.yaml.out
+++ b/test/golden/petstore.yaml.out
@@ -11,7 +11,6 @@ module Test.Api where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -59,7 +58,7 @@ data Api m = Api {
         m ShowPetByIdResponse
 }
 
-application :: (Control.Monad.Catch.MonadCatch m, Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
+application :: (Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
 application run api notFound request respond =
     case Network.Wai.pathInfo request of
         ["pets"] ->
@@ -67,12 +66,12 @@ application run api notFound request respond =
                 "GET" ->
                     optionalQueryParameter "limit" False (\__limit request respond ->
                         run request (do
-                            response <- Control.Monad.Catch.handle pure (listPets api __limit)
+                            response <- listPets api __limit
                             Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                         )) request respond
                 "POST" ->
                     run request (do
-                        response <- Control.Monad.Catch.handle pure (createPets api)
+                        response <- createPets api
                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                     )
                 x ->
@@ -83,7 +82,7 @@ application run api notFound request respond =
                 case Network.Wai.requestMethod request of
                     "GET" ->
                         run request (do
-                            response <- Control.Monad.Catch.handle pure (showPetById api __petId)
+                            response <- showPetById api __petId
                             Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                         )
                     x ->
@@ -94,6 +93,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 
@@ -316,7 +316,6 @@ module Test.Response.CreatePets where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -344,8 +343,6 @@ data CreatePetsResponse
     | CreatePetsDefaultResponse Network.HTTP.Types.Status Error
     deriving (Show)
 
-instance Control.Exception.Exception CreatePetsResponse
-
 instance ToResponse CreatePetsResponse where
     toResponse (CreatePetsResponse201) =
         Network.Wai.responseBuilder (toEnum 201) ([]) mempty
@@ -365,7 +362,6 @@ module Test.Response.ListPets where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -394,8 +390,6 @@ data ListPetsResponse
     | ListPetsDefaultResponse Network.HTTP.Types.Status Error
     deriving (Show)
 
-instance Control.Exception.Exception ListPetsResponse
-
 instance ToResponse ListPetsResponse where
     toResponse (ListPetsResponse200 x __x_next) =
         Network.Wai.responseBuilder (toEnum 200) ([("x-next", Web.HttpApiData.toHeader __x_next) | Just __x_next <- [__x_next]] ++ [(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -415,7 +409,6 @@ module Test.Response.ShowPetById where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -444,8 +437,6 @@ data ShowPetByIdResponse
     | ShowPetByIdDefaultResponse Network.HTTP.Types.Status Error
     deriving (Show)
 
-instance Control.Exception.Exception ShowPetByIdResponse
-
 instance ToResponse ShowPetByIdResponse where
     toResponse (ShowPetByIdResponse200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -465,7 +456,6 @@ module Test.Schemas.Error where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -526,7 +516,6 @@ module Test.Schemas.Pet where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -591,7 +580,6 @@ module Test.Schemas.Pets where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -627,7 +615,6 @@ library
     , attoparsec
     , base
     , bytestring
-    , exceptions
     , ghc-prim
     , http-api-data
     , http-types

--- a/test/golden/test1.yaml.out
+++ b/test/golden/test1.yaml.out
@@ -11,7 +11,6 @@ module Test.Api where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -67,7 +66,7 @@ data Api m = Api {
         m GetUserResponse
 }
 
-application :: (Control.Monad.Catch.MonadCatch m, Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
+application :: (Control.Monad.IO.Class.MonadIO m) => (forall a . Network.Wai.Request -> m a -> IO a) -> Api m -> Network.Wai.Application -> Network.Wai.Application
 application run api notFound request respond =
     case Network.Wai.pathInfo request of
         ["users", __id, "create", __name] ->
@@ -78,7 +77,7 @@ application run api notFound request respond =
                             requiredQueryParameter "page" (\__page request respond ->
                                 optionalQueryParameter "offset" False (\__offset request respond ->
                                     run request (do
-                                        response <- Control.Monad.Catch.handle pure (getUser api __id __name __page __offset)
+                                        response <- getUser api __id __name __page __offset
                                         Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                                     )) request respond) request respond
                         "POST" ->
@@ -86,7 +85,7 @@ application run api notFound request respond =
                                 optionalQueryParameter "offset" False (\__offset request respond ->
                                     parseRequestBody [jsonBodyParser] (\body request respond ->
                                         run request (do
-                                            response <- Control.Monad.Catch.handle pure (createUser api __id __name __page __offset body)
+                                            response <- createUser api __id __name __page __offset body
                                             Control.Monad.IO.Class.liftIO (respond $! (toResponse response))
                                         )) request respond) request respond) request respond
                         x ->
@@ -97,6 +96,7 @@ application run api notFound request respond =
     where
         unsupportedMethod _ =
             respond (Network.Wai.responseBuilder (toEnum 405) [] mempty)
+{-# INLINABLE application #-}
 ---------------------
 Test/Request.hs
 
@@ -319,7 +319,6 @@ module Test.Response.CreateUser where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -388,8 +387,6 @@ data CreateUserResponse
     = CreateUserResponse200 CreateUserResponseBody200
     deriving (Show)
 
-instance Control.Exception.Exception CreateUserResponse
-
 instance ToResponse CreateUserResponse where
     toResponse (CreateUserResponse200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -407,7 +404,6 @@ module Test.Response.GetUser where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -435,8 +431,6 @@ data GetUserResponse
     | GetUserResponse404
     deriving (Show)
 
-instance Control.Exception.Exception GetUserResponse
-
 instance ToResponse GetUserResponse where
     toResponse (GetUserResponse200 x) =
         Network.Wai.responseBuilder (toEnum 200) ([(Network.HTTP.Types.hContentType, "application/json")]) (Data.Aeson.fromEncoding (Data.Aeson.toEncoding x))
@@ -456,7 +450,6 @@ module Test.Schemas.Car where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -529,7 +522,6 @@ module Test.Schemas.NISE where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -623,7 +615,6 @@ module Test.Schemas.PackageId where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -772,7 +763,6 @@ module Test.Schemas.Plane where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -854,7 +844,6 @@ module Test.Schemas.Vehicle where
 import qualified Control.Applicative
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Control.Monad.Catch
 import qualified Control.Monad.IO.Class
 import qualified Data.Aeson
 import qualified Data.Aeson.Encoding
@@ -921,7 +910,6 @@ library
     , attoparsec
     , base
     , bytestring
-    , exceptions
     , ghc-prim
     , http-api-data
     , http-types


### PR DESCRIPTION
I am not convinced it's the right approach anymore. Fortunately we never started using it in Production.