### PR TITLE
Change spelling in example app

### DIFF
--- a/example/app/Main.hs
+++ b/example/app/Main.hs
@@ -72,7 +72,7 @@ createPets = do
         },
       Petstore.Pet
         { id = 2,
-          name = "바다 거북",
+          name = "바다거북",
           tag = Just "🐢"
         },
       Petstore.Pet


### PR DESCRIPTION
Afaik this word should not have an extra space in it, for clarity of reading purposes