### PR TITLE
create and upload binaries on tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Main
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    matrix:
+      os:
+        - ubuntu-latest
+        - macOS-latest
+      cabal:
+        - "3.6.2.0"
+      ghc:
+        - "9.2.3"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Haskell
+        uses: haskell/actions/setup@v1.2
+        id: setup-haskell-cabal
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+
+      - name: Build
+        run: cabal install exe:tie --install-method=copy --overwrite-policy=always --installdir=out
+
+      - name: Test
+        run: ./out/tie --help
+
+      - name: Prepare archive
+        run: tar -zcvf ./${{ matrix.os }}.tar.gz -C out tie
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: ./${{ matrix.os }}.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist-newstyle/
 .DS_Store
 out/
 cabal.project.local*
+*.tar.gz


### PR DESCRIPTION
I want to have binaries available in releases, so anyone can consume them as desired.

I don't plan to try to sink my time into static builds, and I don't mind providing the required dynamic libraries in my environments.