### PR TITLE
add version output to tie

### DIFF
--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -13,6 +13,7 @@ import Options.Applicative
     help,
     helper,
     info,
+    infoOption,
     long,
     metavar,
     option,
@@ -28,6 +29,8 @@ import Options.Applicative
 import System.Environment (getArgs)
 import Tie (fileWriter, generate)
 import Prelude hiding (Option)
+import Data.Version (showVersion)
+import Paths_tie (version)
 
 data Input = Input
   { outputDirectory :: FilePath,
@@ -78,12 +81,18 @@ options =
           <> help "OpenAPI specification file"
       )
 
+versioner :: Parser (a -> a)
+versioner = infoOption ("tie " <> showVersion version)
+  ( long "version"
+  <> help "Print Tie version"
+  )
+
 main :: IO ()
 main = do
   Input {..} <-
     execParser $
       info
-        (options <**> helper)
+        (helper <*> versioner <*> options)
         ( fullDesc
             <> progDesc "Generate a Haskell server from an OpenAPI3 specification"
             <> header "tie - openapi3 server code generator"

--- a/tie.cabal
+++ b/tie.cabal
@@ -68,6 +68,7 @@ library
   default-language: Haskell2010
 
 executable tie
+  other-modules:      Paths_tie
   build-depends:
     , base
     , optparse-applicative


### PR DESCRIPTION
* also reorder order of arguments for flag listing on usage+help

fixes https://github.com/scarf-sh/tie/issues/40

```shell
肉 ~/Code/tie version $ cabal run tie -- --help
Up to date
tie - openapi3 server code generator

Usage: tie [--version] [-o|--output DIR] [--module-name MODULE]
           [--package-name PACKAGE] [--extra-package PACKAGE] FILE
  Generate a Haskell server from an OpenAPI3 specification

Available options:
  -h,--help                Show this help text
  --version                Print Tie version
  -o,--output DIR          The directory output (default: "out")
  --module-name MODULE     Name of the generated top level module
                           (default: "OpenAPI")
  --package-name PACKAGE   Name of the generated cabal project
                           (default: "open-api")
  --extra-package PACKAGE  Extra packages to include in the generated cabal
                           project
  FILE                     OpenAPI specification file
肉 ~/Code/tie version $ cabal run tie -- --version
Up to date
tie 0.1.0.0
```