### PR TITLE
don't archive artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,8 @@ jobs:
       - name: Test
         run: ./out/tie --help
 
-      - name: Prepare archive
-        run: tar -zcvf ./${{ matrix.os }}.tar.gz -C out tie
-
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.os }}-binary
-          path: ${{ matrix.os }}.tar.gz
+          name: ${{ matrix.os }}
+          path: ./out/tie


### PR DESCRIPTION
Sorry, I realized that I should not put this in a tar beforehand, otherwise we end up with zip files with tars in them from artifacts download...