### PR TITLE
revert artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Prepare archive
         run: tar -zcvf ./${{ matrix.os }}.tar.gz -C out tie
 
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          name: ${{ matrix.os }}-binary
-          path: ${{ matrix.os }}.tar.gz
+          files: ./${{ matrix.os }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,11 @@ jobs:
       - name: Test
         run: ./out/tie --help
 
+      - name: Prepare archive
+        run: tar -zcvf ./${{ matrix.os }}.tar.gz -C out tie
+
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.os }}
-          path: ./out/tie
+          name: ${{ matrix.os }}-binary
+          path: ${{ matrix.os }}.tar.gz


### PR DESCRIPTION
- Revert "don't archive artifact upload"
- Revert "upload build artifacts instead of creating releases"

I found that we cannot use build artifacts instead of uploading release artifacts, because build artifacts cannot be referred to and downloaded as static assets. So I am reverting these commits as these are unusable.
