### PR TITLE
restore compatibility between petstore-example and petstore-api

### DIFF
--- a/example/petstore-example.cabal
+++ b/example/petstore-example.cabal
@@ -29,7 +29,7 @@ executable petstore-example
   -- LANGUAGE extensions used by modules in this package.
   -- other-extensions:
   build-depends:
-    , base          ^>=4.14.3.0
+    , base
     , mtl
     , petstore-api
     , text


### PR DESCRIPTION
`cabal run` with too recent versions of GHC installed doesn't work.

```bash
$ cabal run
Resolving dependencies...
Error: cabal: Could not resolve dependencies:
[__0] trying: petstore-api-0.1.0.0 (user goal)
[__1] trying: base-4.16.4.0/installed-4.16.4.0 (dependency of petstore-api)
[__2] next goal: petstore-example (user goal)
[__2] rejecting: petstore-example-0.1.0.0 (conflict:
base==4.16.4.0/installed-4.16.4.0, petstore-example => base^>=4.14.3.0)
[__2] fail (backjumping, conflict set: base, petstore-example)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: base, petstore-example, petstore-api
```