### PR TITLE
embed templates into the build

### DIFF
--- a/src/Tie/Codegen/Request.hs
+++ b/src/Tie/Codegen/Request.hs
@@ -1,20 +1,22 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Tie.Codegen.Request (codegenRequestAuxFile) where
 
 import qualified Data.ByteString as ByteString
 import qualified Data.Text as Text
-import Paths_tie (getDataFileName)
+import Data.FileEmbed (embedStringFile, makeRelativeToProject)
 import Prettyprinter (Doc, hsep, vsep)
 import qualified Prettyprinter.Util as Prettyprinter
 import System.IO.Unsafe (unsafePerformIO)
 import Tie.Name (Name)
 
+templateContents :: ByteString
+templateContents = $(embedStringFile =<< makeRelativeToProject "Request.template.hs")
+
 auxTemplate :: Text
-auxTemplate = unsafePerformIO $ do
-  file <- getDataFileName "Request.template.hs"
-  contents <- ByteString.readFile file
-  pure (decodeUtf8 contents)
+auxTemplate = decodeUtf8 templateContents
 {-# NOINLINE auxTemplate #-}
 
 codegenRequestAuxFile ::

--- a/src/Tie/Codegen/Response.hs
+++ b/src/Tie/Codegen/Response.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Tie.Codegen.Response
   ( codegenResponses,
@@ -13,7 +14,7 @@ import qualified Data.ByteString as ByteString
 import Data.List (lookup)
 import qualified Data.Text as Text
 import Network.HTTP.Media (renderHeader)
-import Paths_tie (getDataFileName)
+import Data.FileEmbed (embedStringFile, makeRelativeToProject)
 import Prettyprinter (Doc, (<+>))
 import qualified Prettyprinter as PP
 import qualified Prettyprinter.Render.Text as PP
@@ -313,11 +314,11 @@ codegenToResponses responseModuleName operationName responses defaultResponse =
               )
    in decl
 
+templateContents :: ByteString
+templateContents = $(embedStringFile =<< makeRelativeToProject "Response.template.hs")
+
 auxTemplate :: Text
-auxTemplate = unsafePerformIO $ do
-  file <- getDataFileName "Response.template.hs"
-  contents <- ByteString.readFile file
-  pure (decodeUtf8 contents)
+auxTemplate = decodeUtf8 templateContents
 {-# NOINLINE auxTemplate #-}
 
 codegenResponseAuxFile ::

--- a/tie.cabal
+++ b/tie.cabal
@@ -13,12 +13,10 @@ author:             Alex Biehl (alex@scarf.sh)
 maintainer:         alex@scarf.sh, engineering@scarf.sh
 copyright:          (c) 2022 Scarf Systems
 category:
-extra-source-files: CHANGELOG.md
-data-files:
+extra-source-files:
+  CHANGELOG.md
   Response.template.hs
   Request.template.hs
-  test/golden/**/*.out
-  test/golden/**/*.yaml
 
 source-repository head
   type:     git
@@ -48,6 +46,7 @@ library
     , containers
     , directory
     , filepath
+    , file-embed
     , http-media
     , insert-ordered-containers
     , lens
@@ -99,6 +98,7 @@ test-suite tie-tests
     , bytestring
     , containers
     , filepath
+    , file-embed
     , hspec
     , insert-ordered-containers
     , openapi3


### PR DESCRIPTION
This gets around our problem with data-files references not being accessible to the binary. Instead, this embeds the files into the binary on build and on cabal install so that we don't run into this problem.